### PR TITLE
Add limelight.vim support

### DIFF
--- a/colors/miramare.vim
+++ b/colors/miramare.vim
@@ -1385,6 +1385,10 @@ highlight! link helpSectionDelim Grey
 " }}}
 " }}}
 " Plugins: {{{
+" junegnn/limelight.vim{{{
+let g:limelight_conceal_guifg = s:palette.grey[0]
+let g:limelight_conceal_ctermfg = s:palette.bg4[1]
+" }}}
 " junegunn/vim-plug{{{
 call s:HL('plug1', s:palette.orange, s:palette.none, 'bold')
 call s:HL('plugNumber', s:palette.yellow, s:palette.none, 'bold')

--- a/colors/miramare.vim
+++ b/colors/miramare.vim
@@ -1385,7 +1385,7 @@ highlight! link helpSectionDelim Grey
 " }}}
 " }}}
 " Plugins: {{{
-" junegnn/limelight.vim{{{
+" junegunn/limelight.vim{{{
 let g:limelight_conceal_guifg = s:palette.grey[0]
 let g:limelight_conceal_ctermfg = s:palette.bg4[1]
 " }}}


### PR DESCRIPTION
I usually use [goyo](https://github.com/junegunn/goyo.vim) and [limelight](https://github.com/junegunn/limelight.vim) together. However, because I set a transparent background, limelight wasn't working. I thought that adding support in the theme for limelight so it also conforms with the palette would be a nice addition.